### PR TITLE
fix: add in-memory data caching, singleton TypeAdapters, and concurrency limiter

### DIFF
--- a/deadlock_assets_api/routes/v1.py
+++ b/deadlock_assets_api/routes/v1.py
@@ -10,6 +10,12 @@ from deadlock_assets_api.models.v1.steam_info import SteamInfoV1
 
 router = APIRouter(prefix="/v1")
 
+# Pre-compiled TypeAdapters — avoids re-building schemas on every request
+_TA_COLORS = TypeAdapter(dict[str, ColorV1])
+_TA_ICONS = TypeAdapter(dict[str, str])
+_TA_IMAGES = TypeAdapter(dict[str, str])
+_TA_SOUNDS = TypeAdapter(dict[str, str | dict])
+
 
 @router.get("/map", response_model_exclude_none=True)
 def get_map(client_version: ValidClientVersions | None = None) -> MapV1:
@@ -24,8 +30,7 @@ def get_map(client_version: ValidClientVersions | None = None) -> MapV1:
 def get_colors(client_version: ValidClientVersions | None = None) -> dict[str, ColorV1]:
     if client_version is None:
         client_version = ValidClientVersions(LATEST_VERSION)
-    ta = TypeAdapter(dict[str, ColorV1])
-    return utils.read_parse_data_ta(f"deploy/versions/{client_version.value}/colors_data.json", ta)
+    return utils.read_parse_data_ta(f"deploy/versions/{client_version.value}/colors_data.json", _TA_COLORS)
 
 
 @router.get("/steam-info")
@@ -39,21 +44,18 @@ def get_steam_info(client_version: ValidClientVersions | None = None) -> SteamIn
 def get_icons(client_version: ValidClientVersions | None = None) -> dict[str, str]:
     if client_version is None:
         client_version = ValidClientVersions(LATEST_VERSION)
-    ta = TypeAdapter(dict[str, str])
-    return utils.read_parse_data_ta(f"deploy/versions/{client_version.value}/icons_data.json", ta)
+    return utils.read_parse_data_ta(f"deploy/versions/{client_version.value}/icons_data.json", _TA_ICONS)
 
 
 @router.get("/images", response_model_exclude_none=True)
 def get_images(client_version: ValidClientVersions | None = None) -> dict[str, str]:
     if client_version is None:
         client_version = ValidClientVersions(LATEST_VERSION)
-    ta = TypeAdapter(dict[str, str])
-    return utils.read_parse_data_ta(f"deploy/versions/{client_version.value}/images_data.json", ta)
+    return utils.read_parse_data_ta(f"deploy/versions/{client_version.value}/images_data.json", _TA_IMAGES)
 
 
 @router.get("/sounds", response_model_exclude_none=True)
 def get_sounds(client_version: ValidClientVersions | None = None) -> dict:
     if client_version is None:
         client_version = ValidClientVersions(LATEST_VERSION)
-    ta = TypeAdapter(dict[str, str | dict])
-    return utils.read_parse_data_ta(f"deploy/versions/{client_version.value}/sounds_data.json", ta)
+    return utils.read_parse_data_ta(f"deploy/versions/{client_version.value}/sounds_data.json", _TA_SOUNDS)

--- a/deadlock_assets_api/routes/v2.py
+++ b/deadlock_assets_api/routes/v2.py
@@ -18,6 +18,15 @@ from deadlock_assets_api.models.v2.rank import RankV2
 
 router = APIRouter(prefix="/v2")
 
+# Pre-compiled TypeAdapters — avoids re-building schemas on every request
+_TA_HEROES = TypeAdapter(list[HeroV2])
+_TA_ITEMS = TypeAdapter(list[ItemV2])
+_TA_ACCOLADES = TypeAdapter(list[AccoladeV2])
+_TA_NPC_UNITS = TypeAdapter(list[NPCUnitV2])
+_TA_MISC = TypeAdapter(list[MiscV2])
+_TA_RANKS = TypeAdapter(list[RankV2])
+_TA_BUILD_TAGS = TypeAdapter(list[BuildTagV2])
+
 
 @router.get("/heroes", response_model_exclude_none=True, tags=["Heroes"])
 def get_heroes(
@@ -30,9 +39,8 @@ def get_heroes(
     language = utils.validate_language(language)
     client_version = utils.validate_client_version(client_version)
 
-    ta = TypeAdapter(list[HeroV2])
     heroes = utils.read_parse_data_ta(
-        f"deploy/versions/{client_version}/heroes/{language.value}.json", ta
+        f"deploy/versions/{client_version}/heroes/{language.value}.json", _TA_HEROES
     )
     if only_active:
         heroes = [h for h in heroes if not h.disabled]
@@ -75,9 +83,8 @@ def get_items(
     language = utils.validate_language(language)
     client_version = utils.validate_client_version(client_version)
 
-    ta = TypeAdapter(list[ItemV2])
     return utils.read_parse_data_ta(
-        f"deploy/versions/{client_version}/items/{language.value}.json", ta
+        f"deploy/versions/{client_version}/items/{language.value}.json", _TA_ITEMS
     )
 
 
@@ -146,9 +153,8 @@ def get_accolades(
     language = utils.validate_language(language)
     client_version = utils.validate_client_version(client_version)
 
-    ta = TypeAdapter(list[AccoladeV2])
     accolades = utils.read_parse_data_ta(
-        f"deploy/versions/{client_version}/accolades/{language.value}.json", ta
+        f"deploy/versions/{client_version}/accolades/{language.value}.json", _TA_ACCOLADES
     )
     return accolades
 
@@ -185,8 +191,7 @@ def get_npc_units(
 ) -> list[NPCUnitV2]:
     client_version = utils.validate_client_version(client_version)
 
-    ta = TypeAdapter(list[NPCUnitV2])
-    return utils.read_parse_data_ta(f"deploy/versions/{client_version}/npc_units.json", ta)
+    return utils.read_parse_data_ta(f"deploy/versions/{client_version}/npc_units.json", _TA_NPC_UNITS)
 
 
 @router.get("/npc-units/{id_or_class_name}", response_model_exclude_none=True, tags=["NPC Units"])
@@ -208,8 +213,7 @@ def get_misc_entities(
 ) -> list[MiscV2]:
     client_version = utils.validate_client_version(client_version)
 
-    ta = TypeAdapter(list[MiscV2])
-    return utils.read_parse_data_ta(f"deploy/versions/{client_version}/misc_entities.json", ta)
+    return utils.read_parse_data_ta(f"deploy/versions/{client_version}/misc_entities.json", _TA_MISC)
 
 
 @router.get(
@@ -239,9 +243,8 @@ def get_ranks(
 ) -> list[RankV2]:
     language = utils.validate_language(language)
     client_version = utils.validate_client_version(client_version)
-    ta = TypeAdapter(list[RankV2])
     return utils.read_parse_data_ta(
-        f"deploy/versions/{client_version}/ranks/{language.value}.json", ta
+        f"deploy/versions/{client_version}/ranks/{language.value}.json", _TA_RANKS
     )
 
 
@@ -252,9 +255,8 @@ def get_build_tags(
 ) -> list[BuildTagV2]:
     language = utils.validate_language(language)
     client_version = utils.validate_client_version(client_version)
-    ta = TypeAdapter(list[BuildTagV2])
     return utils.read_parse_data_ta(
-        f"deploy/versions/{client_version}/build_tags/{language.value}.json", ta
+        f"deploy/versions/{client_version}/build_tags/{language.value}.json", _TA_BUILD_TAGS
     )
 
 


### PR DESCRIPTION
Response times were 200s+ due to three compounding issues:
- Every request read JSON from disk and ran full Pydantic validation
- TypeAdapters were re-compiled on every request call
- No limit on concurrent requests, causing cascading slowdowns

Changes:
- Cache parsed data in-memory in utils._data_cache (data is static, only
  changes on deploy/restart)
- Pre-create TypeAdapters as module-level singletons in v1.py and v2.py
- Add concurrency limiter middleware (default 100, configurable via
  MAX_CONCURRENT_REQUESTS env var) that returns 503 with Retry-After
  header when capacity is exceeded

https://claude.ai/code/session_01AnESsvQYduio1dW5Ni4bNF