### PR TITLE
Expose client version asset availability

### DIFF
--- a/deadlock_assets_api/availability.py
+++ b/deadlock_assets_api/availability.py
@@ -1,0 +1,44 @@
+import os
+from typing import TypedDict
+
+
+class ClientVersionAvailability(TypedDict):
+    client_version: int
+    items: bool
+    generic_data: bool
+    images: bool
+    nearest_images_version: int | None
+
+
+def version_file_exists(client_version: int, relative_path: str) -> bool:
+    return os.path.exists(f"deploy/versions/{client_version}/{relative_path}")
+
+
+def nearest_version_with_file(
+    client_version: int, client_versions: list[int], relative_path: str
+) -> int | None:
+    candidates = [
+        version
+        for version in client_versions
+        if version_file_exists(version, relative_path)
+    ]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda version: (abs(version - client_version), -version))
+
+
+def get_client_version_availability(
+    client_versions: list[int],
+) -> list[ClientVersionAvailability]:
+    return [
+        {
+            "client_version": version,
+            "items": version_file_exists(version, "items/english.json"),
+            "generic_data": version_file_exists(version, "generic_data.json"),
+            "images": version_file_exists(version, "images_data.json"),
+            "nearest_images_version": nearest_version_with_file(
+                version, client_versions, "images_data.json"
+            ),
+        }
+        for version in client_versions
+    ]

--- a/deadlock_assets_api/availability.py
+++ b/deadlock_assets_api/availability.py
@@ -18,9 +18,7 @@ def nearest_version_with_file(
     client_version: int, client_versions: list[int], relative_path: str
 ) -> int | None:
     candidates = [
-        version
-        for version in client_versions
-        if version_file_exists(version, relative_path)
+        version for version in client_versions if version_file_exists(version, relative_path)
     ]
     if not candidates:
         return None

--- a/deadlock_assets_api/routes/v2.py
+++ b/deadlock_assets_api/routes/v2.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import TypeAdapter
 
 from deadlock_assets_api import utils
+from deadlock_assets_api.availability import get_client_version_availability
 from deadlock_assets_api.models.enums import ValidClientVersions, ALL_CLIENT_VERSIONS
 from deadlock_assets_api.models.languages import Language
 from deadlock_assets_api.models.v2.api_accolade import AccoladeV2
@@ -238,6 +239,11 @@ def get_misc_entity(
 @router.get("/client-versions")
 def get_client_versions() -> list[int]:
     return ALL_CLIENT_VERSIONS
+
+
+@router.get("/client-version-availability")
+def get_client_versions_availability() -> list[dict[str, int | bool | None]]:
+    return get_client_version_availability(ALL_CLIENT_VERSIONS)
 
 
 @router.get("/ranks", response_model_exclude_none=True)

--- a/tests/test_client_version_availability.py
+++ b/tests/test_client_version_availability.py
@@ -1,0 +1,50 @@
+import json
+from pathlib import Path
+
+from deadlock_assets_api.availability import get_client_version_availability
+
+
+def write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+def test_client_version_availability_reports_payload_coverage(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    write_json(Path("deploy/versions/6016/items/english.json"), [])
+    write_json(Path("deploy/versions/6016/generic_data.json"), {})
+    write_json(Path("deploy/versions/6016/images_data.json"), {"image": "url"})
+    write_json(Path("deploy/versions/5959/items/english.json"), [])
+    write_json(Path("deploy/versions/5959/generic_data.json"), {})
+
+    availability = get_client_version_availability([6016, 5959])
+
+    assert availability == [
+        {
+            "client_version": 6016,
+            "items": True,
+            "generic_data": True,
+            "images": True,
+            "nearest_images_version": 6016,
+        },
+        {
+            "client_version": 5959,
+            "items": True,
+            "generic_data": True,
+            "images": False,
+            "nearest_images_version": 6016,
+        },
+    ]
+
+
+def test_client_version_availability_handles_no_image_manifests(
+    tmp_path: Path, monkeypatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    write_json(Path("deploy/versions/5959/items/english.json"), [])
+
+    availability = get_client_version_availability([5959])
+
+    assert availability[0]["nearest_images_version"] is None

--- a/tests/test_client_version_availability.py
+++ b/tests/test_client_version_availability.py
@@ -9,9 +9,7 @@ def write_json(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload))
 
 
-def test_client_version_availability_reports_payload_coverage(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_client_version_availability_reports_payload_coverage(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.chdir(tmp_path)
     write_json(Path("deploy/versions/6016/items/english.json"), [])
     write_json(Path("deploy/versions/6016/generic_data.json"), {})


### PR DESCRIPTION
## Summary
- Add a helper for per-client-version payload coverage.
- Expose GET /v2/client-version-availability.
- Include items, generic_data, images, and nearest_images_version fields.

## Tests
- PYTHONPATH=. python -m pytest tests/test_client_version_availability.py -q
- python -m ruff format deadlock_assets_api tests/test_client_version_availability.py
- python -m ruff check deadlock_assets_api tests/test_client_version_availability.py
- PYTHONPATH=. python -m compileall -q deadlock_assets_api tests/test_client_version_availability.py
